### PR TITLE
Added missing words in comment in progress-bar.css

### DIFF
--- a/src/assets/css/progress-bar.css
+++ b/src/assets/css/progress-bar.css
@@ -7,7 +7,7 @@
  * 2. Needed to keep bar the same height in Firefox vs Webkit
  * 3. Webkit will need ::-webkit-progress-bar to set background
  * 4. Set overflow hidden so as to not have to re-do border-radius
- *    again for
+ *    again for the progress indicator
  */
 
 .progress-bar {


### PR DESCRIPTION
One of the comments in `progress-bar.css` missed a couple of words to finish the sentence:

```css
 * 4. Set overflow hidden so as to not have to re-do border-radius
 *    again for

...

.progress-bar {
        ...
	overflow: hidden; /* 4 */
        ...
}
```

I just completed the sentence: ... `again for the progress indicator`.
