### PR TITLE
Fixed indentation of opening `div` tag in markup example

### DIFF
--- a/src/search/index.html
+++ b/src/search/index.html
@@ -128,7 +128,7 @@
 						<details open>
 							<summary>Pattern Markup</summary>
 						<pre><code class="language-html">&lt;form role="search" aria-label="unique identifier could go here">
-	&lt;div class="search-widget">
+  &lt;div class="search-widget">
     &lt;input type="search" &lt;!-- or type="text" -->
       id="srch"
       name="srch"


### PR DESCRIPTION
The opening `div` tag in the markup example had two spaces too many, making the nested structure of the markup hard to see.

#### Before the fix

<figure>
  <figcaption>Before the fix, the opening <code>div</code> was indented at the same level as its content, and more than the corresponding closing tag:</figcaption>
  <img width="621" alt="Screenshot 2019-10-12 at 14 38 45" src="https://user-images.githubusercontent.com/30028540/66702447-a1fc6880-ecff-11e9-9163-a8e0ca479286.png">
</figure>

#### After the fix

<figure>
  <figcaption>After the fix, the opening <code>div</code> is now indented one level less than its content:</figcaption>
  <img width="616" alt="Screenshot 2019-10-12 at 14 45 34" src="https://user-images.githubusercontent.com/30028540/66702390-1f73a900-ecff-11e9-91c7-cd44a6cb7be1.png">
</figure>

