### PR TITLE
add more checkbox examples

### DIFF
--- a/src/assets/css/checkbox-alt.css
+++ b/src/assets/css/checkbox-alt.css
@@ -21,8 +21,8 @@
   transition: transform .2s ease-in-out;
 }
 
-.s-cb input:before,
-.s-cb input:after {
+.s-cb input::before,
+.s-cb input::after {
   border-bottom: 3px solid rgba(34, 139, 236, 1);
   border-right: 3px solid rgba(34, 139, 236, 1);
   bottom: 0;
@@ -39,7 +39,7 @@
   box-shadow: inset 0 0 20px 3px rgba(34, 139, 236, .05);
 }
 
-.s-cb input:checked:before {
+.s-cb input:checked::before {
   transform: rotate(45deg) scale(1);
 }
 
@@ -50,16 +50,43 @@
   outline-offset: 3px;
 }
 
+/** 
+ * Indeterminate (mixed) style
+ */
+.s-cb input:indeterminate::after {
+  border-bottom-width: 4px;
+  border-right-width: 0px;
+  bottom: 0;
+  height: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  transform: none;
+  width: 1em;
+}
+
 
 /**
  * Disabled styles
  */
 .s-cb input[disabled] {
-  opacity: .45
+  opacity: .45;
 }
 
 .s-cb input[disabled] + label {
-  opacity: .75;
+  opacity: .825;
+}
+
+.s-cb input[disabled].informative {
+  border: none;
+  box-shadow: none;
+  opacity: 1;
+}
+
+.s-cb input[disabled].informative::before {
+  border-bottom-color: #000;
+  border-right-color: #000;
+  transform: rotate(45deg) scale(1.3)
 }
 
 
@@ -67,9 +94,9 @@
    allow for a required visual indicator to be absolutely positioned
 */
 .s-cb label {
-  position: relative;
   left: -.25em;
   padding-left: .75em;
+  position: relative;
 }
 
 /* if a checkbox is required, make some space for the
@@ -96,8 +123,8 @@
 /**
  * Create a visual indicator for the required checkbox
  */
-.s-cb input[required] + label:after,
-.s-cb input[required] + label:before {
+.s-cb input[required] + label::after,
+.s-cb input[required] + label::before {
   border-left: .35em solid transparent;
   border-right: .35em solid transparent;
   content: " ";

--- a/src/assets/css/checkbox.css
+++ b/src/assets/css/checkbox.css
@@ -37,7 +37,7 @@
  * It must be the same height, width and
  * position of the native checkbox element.
  */
-.c-cb > label:before,
+.c-cb > label::before,
 .c-cb > input[type="checkbox"] {
 	height: 1.125em;
 	left: .125em;
@@ -48,8 +48,8 @@
  * Base styles for use on both
  * pseudo elements.
  */
-.c-cb > label:before,
-.c-cb > label:after {
+.c-cb > label::before,
+.c-cb > label::after {
 	border: 1px solid;
 	content: " ";
 	position: absolute;
@@ -62,7 +62,7 @@
 /**
  * Styles for the custom box boundary.
  */
-.c-cb > label:before {
+.c-cb > label::before {
 	border-color: #565656;
 	border-radius: 2px;
 	box-shadow: 0 0 0 1px #565656;
@@ -91,38 +91,38 @@
 /**
  * ** Defining States **
  */
-.c-cb > input:checked ~ label:before {
+.c-cb > input:checked ~ label::before {
 	border-color: transparent;
 	box-shadow: 0 0 0 2px #0d5192;
 }
 
-.c-cb > input:focus ~ label:before {
+.c-cb > input:focus ~ label::before {
 	border-color: transparent;
 	box-shadow: 0 0 0 3px #228BEC;
-	outline-offset: 2px;
 	outline: 2px solid transparent;
+	outline-offset: 2px;
 }
 
-.c-cb > input:checked ~ label:after {
+.c-cb > input:checked ~ label::after {
 	transform: rotate(45deg) scale(1);
 }
 
-.c-cb > input:checked:focus ~ label:after {
+.c-cb > input:checked:focus ~ label::after {
 	border-color: #228BEC;
 }
 
 .c-cb > input[disabled] ~ label {
-	opacity: .625;
+	opacity: .825;
 }
 
 /* placeholder design until a better required
    design pattern can be created */
-.c-cb > input:invalid ~ label:before {
+.c-cb > input:invalid ~ label::before {
 	border-color: #f00;
 	box-shadow: 0 0 0 1px #f00;
 }
 
-.c-cb > input:invalid:focus ~ label:before {
+.c-cb > input:invalid:focus ~ label::before {
 	box-shadow: 0 0 0 2px #f00;
 }
 
@@ -132,14 +132,14 @@
 
 
 .c-cb input[required] ~ label .req-star {
-	position: relative;
 	display: inline-block;
+	position: relative;
 	right: -.7em;
 	top: -1em;
 }
 
-.c-cb input[required] ~ label .req-star:after,
-.c-cb input[required] ~ label .req-star:before {
+.c-cb input[required] ~ label .req-star::after,
+.c-cb input[required] ~ label .req-star::before {
   border-left: .35em solid transparent;
   border-right: .35em solid transparent;
   content: " ";
@@ -147,21 +147,21 @@
   right: 0;
 }
 
-.c-cb input[required] ~ label .req-star:after {
+.c-cb input[required] ~ label .req-star::after {
  border-bottom: .6em solid red;
  top: -.2em;
 }
 
-.c-cb input[required] ~ label .req-star:before {
+.c-cb input[required] ~ label .req-star::before {
  border-top: .6em solid red;
  top: 0
 }
 
 /* when checked, ease up on the "error" feel to the indicator */
-.c-cb input[required]:checked + label .req-star:after {
+.c-cb input[required]:checked + label .req-star::after {
   border-bottom-color: rgba(34, 139, 236, .8);
 }
 
-.c-cb input[required]:checked + label .req-star:before {
+.c-cb input[required]:checked + label .req-star::before {
   border-top-color: rgba(34, 139, 236, .8);
 }

--- a/src/checkbox/index.html
+++ b/src/checkbox/index.html
@@ -35,7 +35,7 @@
           <header>
             <h1>Styled HTML Checkboxes</h1>
             <p>Published: <span>July 26, 2018</span></p>
-            <p>Last updated: <span>September 25, 2021</span></p>
+            <p>Last updated: <span>January 13, 2022</span></p>
             <p>
               Cross-browser styling for native HTML checkboxes.
             </p>
@@ -62,9 +62,16 @@
               </label>
             </div>
             <div class="s-cb">
-              <input type="checkbox" id="s_input_2" disabled>
+              <input type="checkbox" id="s_input_2a" disabled>
               <label for="s_input_2">
-                Option 2
+                Option 2a
+                (this option is disabled)
+              </label>
+            </div>
+            <div class="s-cb">
+              <input type="checkbox" id="s_input_2b" disabled class="informative">
+              <label for="s_input_2">
+                Option 2b
                 (this option is disabled)
               </label>
             </div>
@@ -74,6 +81,16 @@
                 Option 3 is required
               </label>
             </div>
+            <div class="s-cb">
+              <input type="checkbox" id="s_input_4">
+              <label for="s_input_3">
+                Option 4 (mixed)
+              </label>
+            </div>
+            <script>
+              const mixed = document.getElementById('s_input_4');
+              mixed.indeterminate = true;
+            </script>
           </fieldset>
 
 


### PR DESCRIPTION
adds a demonstration of having a disabled checkbox with a high-contrast checkmark, for when a checked state is important to ensure it is visually indicated to all users, but still not interactive.

adds demonstration of a mixed state checkbox using the indeterminate idl attribute